### PR TITLE
Adding fine grained azure groups thats allowed

### DIFF
--- a/pritunl/settings/app.py
+++ b/pritunl/settings/app.py
@@ -1,6 +1,5 @@
 from pritunl.settings.group_mongo import SettingsGroupMongo
 
-
 class SettingsApp(SettingsGroupMongo):
     group = 'app'
     fields = {

--- a/pritunl/settings/app.py
+++ b/pritunl/settings/app.py
@@ -1,5 +1,6 @@
 from pritunl.settings.group_mongo import SettingsGroupMongo
 
+
 class SettingsApp(SettingsGroupMongo):
     group = 'app'
     fields = {
@@ -89,6 +90,8 @@ class SettingsApp(SettingsGroupMongo):
         'sso_timeout': 60,
         'sso_org': None,
         'sso_azure_mode': 'org',
+        'sso_azure_allow_groups': [],
+        'sso_azure_security_groups_only': False,
         'sso_azure_directory_id': None,
         'sso_azure_app_id': None,
         'sso_azure_app_secret': None,

--- a/pritunl/sso/azure.py
+++ b/pritunl/sso/azure.py
@@ -99,7 +99,6 @@ def _verify_azure_1(user_name):
 
     return True, roles
 
-
 def _verify_azure_2(user_name):
     response = requests.post(
         'https://login.microsoftonline.com/%s/oauth2/token' % \
@@ -223,7 +222,6 @@ def _verify_azure_2(user_name):
             return False, []
 
     return True, roles
-
 
 def verify_azure(user_name):
     if settings.app.sso_azure_version == 1:

--- a/pritunl/sso/azure.py
+++ b/pritunl/sso/azure.py
@@ -99,6 +99,7 @@ def _verify_azure_1(user_name):
 
     return True, roles
 
+
 def _verify_azure_2(user_name):
     response = requests.post(
         'https://login.microsoftonline.com/%s/oauth2/token' % \
@@ -183,7 +184,7 @@ def _verify_azure_2(user_name):
                 'Content-Type': 'application/json',
             },
             json={
-                'securityEnabledOnly': 'false',
+                'securityEnabledOnly': str(settings.app.sso_azure_security_groups_only).lower(),
             },
             timeout=20,
         )
@@ -203,6 +204,8 @@ def _verify_azure_2(user_name):
             display_name = group_data.get('displayName')
             if not display_name:
                 continue
+            if settings.app.sso_azure_allow_groups and display_name.replace(" ","_").replace("'","") not in settings.app.sso_azure_allow_groups:
+                continue
             roles.append(display_name)
 
         next_url = data.get('@odata.nextLink')
@@ -220,6 +223,7 @@ def _verify_azure_2(user_name):
             return False, []
 
     return True, roles
+
 
 def verify_azure(user_name):
     if settings.app.sso_azure_version == 1:


### PR DESCRIPTION
Currently when setting the `app.sso_azure_mode` to `groups` it will sync all groups from Azure (Security and Distribution groups). This also not handled very good on the ui when viewing the users as it will overflow and getting all the groups synced was not very useful for us.

The suggested changes are the ability to select if you want only security groups or all groups, where currently all groups are forced. Usually security groups will be used for access control. Then also have a new list option to filter out which groups to be allowed to be synced.

These changes are really hard to test in a local dev environment as it requires a valid license.

So to completely make us of this feature you need to set the following.
```
app.sso_azure_mode = "groups"
app.sso_azure_security_groups_only = true
app.sso_azure_allow_groups = [ "AD_GROUP_NAME_ONE", "AD_GROUP_NAME_TWO" ]
```
So if the user logs in and they are assigned to security group `AD_GROUP_NAME_ONE` or `AD_GROUP_NAME_TWO` it will be added to their profile.